### PR TITLE
Add mini-agent solution with multi-step execution workflow

### DIFF
--- a/agentic-ai-systems/mini-agent-solution-multi-step/README.md
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/README.md
@@ -1,0 +1,24 @@
+# Mini Agent Solution
+
+A small modular Python project that demonstrates a multi-step agent workflow:
+
+1. Analyze task
+2. Plan solution
+3. Execute tool calls
+4. Validate result
+
+## Structure
+
+- `agent/analyzer.py`: intent and entity extraction
+- `agent/planner.py`: per-intent execution plans
+- `agent/tools/`: mock weather and pricing tools
+- `agent/executor.py`: plan execution with trace
+- `agent/validator.py`: result validation
+- `agent/orchestrator.py`: `run_agent` end-to-end flow
+- `main.py`: sample tasks runner
+
+## Run
+
+```bash
+python main.py
+```

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/__init__.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/__init__.py
@@ -1,0 +1,3 @@
+from .orchestrator import run_agent
+
+__all__ = ["run_agent"]

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/analyzer.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/analyzer.py
@@ -1,0 +1,34 @@
+import re
+
+
+def analyze_task(task):
+    """Extract intent and entity from a task string."""
+    normalized_task = task.strip()
+    lowered = normalized_task.lower()
+
+    if "weather" in lowered:
+        city_match = re.search(r"weather\s+in\s+(.+)$", normalized_task, re.IGNORECASE)
+        city = city_match.group(1).strip() if city_match else None
+        return {
+            "intent": "get_weather",
+            "entity_type": "city",
+            "entity": city,
+            "confidence": 0.95 if city else 0.65,
+        }
+
+    if "price" in lowered:
+        product_match = re.search(r"price\s+of\s+(.+)$", normalized_task, re.IGNORECASE)
+        product = product_match.group(1).strip() if product_match else None
+        return {
+            "intent": "get_price",
+            "entity_type": "product",
+            "entity": product,
+            "confidence": 0.95 if product else 0.65,
+        }
+
+    return {
+        "intent": "unknown",
+        "entity_type": None,
+        "entity": None,
+        "confidence": 0.2,
+    }

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/config.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/config.py
@@ -1,0 +1,9 @@
+WEATHER_DATA = {
+    "vaasa": {"temperature_c": 7, "condition": "Cloudy", "humidity_pct": 81},
+    "oulu": {"temperature_c": 3, "condition": "Light Snow", "humidity_pct": 88},
+}
+
+PRICE_DATA = {
+    "headphones": {"price_eur": 79.99, "store": "TechHub", "currency": "EUR"},
+    "smartphone": {"price_eur": 699.0, "store": "MobileWorld", "currency": "EUR"},
+}

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/executor.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/executor.py
@@ -1,0 +1,50 @@
+from agent.analyzer import analyze_task
+from agent.tools import query_pricing_tool, query_weather_tool
+
+
+def execute_plan(task, plan):
+    """Execute a plan using mock tool endpoints."""
+    analysis = analyze_task(task)
+    intent = analysis["intent"]
+    entity = analysis["entity"]
+    trace = []
+
+    if intent == "get_weather":
+        trace.append({"step": plan[0], "status": "done"})
+        tool_result = query_weather_tool(entity)
+        trace.append({"step": plan[1], "status": "done", "tool_result": tool_result})
+
+        if tool_result["ok"]:
+            data = tool_result["data"]
+            summary = (
+                f"Weather in {entity}: {data['temperature_c']}C, "
+                f"{data['condition']}, humidity {data['humidity_pct']}%."
+            )
+            trace.append({"step": plan[2], "status": "done"})
+            return {"ok": True, "summary": summary, "raw": data, "trace": trace}
+
+        return {"ok": False, "summary": tool_result["error"], "raw": None, "trace": trace}
+
+    if intent == "get_price":
+        trace.append({"step": plan[0], "status": "done"})
+        tool_result = query_pricing_tool(entity)
+        trace.append({"step": plan[1], "status": "done", "tool_result": tool_result})
+
+        if tool_result["ok"]:
+            data = tool_result["data"]
+            summary = (
+                f"Price of {entity}: {data['price_eur']} {data['currency']} "
+                f"at {data['store']}."
+            )
+            trace.append({"step": plan[2], "status": "done"})
+            return {"ok": True, "summary": summary, "raw": data, "trace": trace}
+
+        return {"ok": False, "summary": tool_result["error"], "raw": None, "trace": trace}
+
+    trace.append({"step": plan[0], "status": "done"})
+    return {
+        "ok": False,
+        "summary": "Unsupported task type. Supported: weather lookup, price lookup.",
+        "raw": None,
+        "trace": trace,
+    }

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/orchestrator.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/orchestrator.py
@@ -1,0 +1,19 @@
+from agent.analyzer import analyze_task
+from agent.executor import execute_plan
+from agent.planner import plan_solution
+from agent.validator import validate_result
+
+
+def run_agent(task):
+    analysis = analyze_task(task)
+    plan = plan_solution(analysis)
+    results = execute_plan(task, plan)
+    validation = validate_result(results)
+
+    return {
+        "task": task,
+        "analysis": analysis,
+        "plan": plan,
+        "results": results,
+        "validation": validation,
+    }

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/planner.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/planner.py
@@ -1,0 +1,20 @@
+def plan_solution(analysis):
+    """Generate a simple, explicit plan from analysis."""
+    intent = analysis["intent"]
+    entity = analysis["entity"]
+
+    if intent == "get_weather":
+        return [
+            "Validate city extracted from user task",
+            f"Call weather tool for city '{entity}'",
+            "Format weather response",
+        ]
+
+    if intent == "get_price":
+        return [
+            "Validate product extracted from user task",
+            f"Call pricing tool for product '{entity}'",
+            "Format price response",
+        ]
+
+    return ["Return graceful fallback for unsupported intent"]

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/__init__.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/__init__.py
@@ -1,0 +1,4 @@
+from .pricing_tool import query_pricing_tool
+from .weather_tool import query_weather_tool
+
+__all__ = ["query_weather_tool", "query_pricing_tool"]

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/pricing_tool.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/pricing_tool.py
@@ -1,0 +1,12 @@
+from agent.config import PRICE_DATA
+
+
+def query_pricing_tool(product):
+    if not product:
+        return {"ok": False, "error": "No product provided"}
+
+    payload = PRICE_DATA.get(product.lower())
+    if not payload:
+        return {"ok": False, "error": f"No price data found for '{product}'"}
+
+    return {"ok": True, "data": payload}

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/weather_tool.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/tools/weather_tool.py
@@ -1,0 +1,12 @@
+from agent.config import WEATHER_DATA
+
+
+def query_weather_tool(city):
+    if not city:
+        return {"ok": False, "error": "No city provided"}
+
+    payload = WEATHER_DATA.get(city.lower())
+    if not payload:
+        return {"ok": False, "error": f"No weather data found for '{city}'"}
+
+    return {"ok": True, "data": payload}

--- a/agentic-ai-systems/mini-agent-solution-multi-step/agent/validator.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/agent/validator.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def validate_result(results):
+    """Validate result completeness and provide diagnostics."""
+    summary = results.get("summary", "")
+    has_summary = isinstance(summary, str) and bool(summary.strip())
+
+    return {
+        "is_valid": bool(results.get("ok")) and has_summary,
+        "has_summary": has_summary,
+        "trace_steps": len(results.get("trace", [])),
+        "validated_at": datetime.utcnow().isoformat() + "Z",
+    }

--- a/agentic-ai-systems/mini-agent-solution-multi-step/main.py
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/main.py
@@ -1,0 +1,18 @@
+from agent.orchestrator import run_agent
+
+
+def main():
+    tasks = [
+        "Get weather in Vaasa",
+        "Get price of headphones",
+        "Get weather in Oulu",
+        "Get price of smartphone",
+    ]
+
+    for task in tasks:
+        response = run_agent(task)
+        print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/agentic-ai-systems/mini-agent-solution-multi-step/requirements.txt
+++ b/agentic-ai-systems/mini-agent-solution-multi-step/requirements.txt
@@ -1,0 +1,1 @@
+# No external dependencies required.


### PR DESCRIPTION
This pull request introduces a new modular Python project, `mini-agent-solution-multi-step`, which demonstrates a multi-step agent workflow for handling simple natural language tasks like weather and price lookups. The implementation is structured for clarity and extensibility, with each agent step encapsulated in its own module. The project includes mock tools, a simple planner, executor, and validator, and a sample runner.

The most important changes are:

**Project Structure and Documentation**
- Added a comprehensive `README.md` describing the multi-step agent workflow, project structure, and usage instructions.
- Introduced a `requirements.txt` noting no external dependencies are required.

**Core Agent Workflow**
- Implemented the orchestrator (`agent/orchestrator.py`) with a `run_agent` function that coordinates task analysis, planning, execution, and validation. [[1]](diffhunk://#diff-4c1268607ed2bcd0f4a3c59a7a3b61462eab8d66b0c12029d64cd1285bcf7ad4R1-R19) [[2]](diffhunk://#diff-3efed3a3ee5c84d4149af7d8b0232c2eca50c4f0f698ab9afc60fc87e6970156R1-R3)
- Added a sample runner in `main.py` to demonstrate the agent's capabilities with example tasks.

**Agent Modules**
- Analyzer: Extracts intent and entities from user tasks (`agent/analyzer.py`).
- Planner: Generates step-by-step execution plans based on analysis (`agent/planner.py`).
- Executor: Executes plans using mock tool APIs and records trace (`agent/executor.py`).
- Validator: Validates results and provides diagnostics (`agent/validator.py`).

**Mock Tools and Configuration**
- Added mock weather and pricing data in `agent/config.py` and implemented corresponding tool interfaces (`agent/tools/weather_tool.py`, `agent/tools/pricing_tool.py`, `agent/tools/__init__.py`). [[1]](diffhunk://#diff-97e0c489a71942e3ef2601348b1760d6ee6e1947a08f77e6f4c7354e211122c5R1-R9) [[2]](diffhunk://#diff-495de617e1e45d1888ab0dbcb5b5206faf2911098e3b2b702a50ae164a1bfa46R1-R12) [[3]](diffhunk://#diff-00fe528cb0c3283b26a8c4535a87c3facc788b20b6a3dac4c80478a17fa2592cR1-R12) [[4]](diffhunk://#diff-03ccc73c165643402eda9b2bf130f650c7904a9b4786cb91f1a68f5c0f26d520R1-R4)